### PR TITLE
Fix crash when using characters not in character sets

### DIFF
--- a/Source/NSString+HYPNetworking.m
+++ b/Source/NSString+HYPNetworking.m
@@ -59,7 +59,7 @@
         NSString *result = [processedString hyp_lowerCaseFirstLetter];
 
         [[[HYPNetworkingStringStorage sharedInstance] lock] lock];
-        [[[HYPNetworkingStringStorage sharedInstance] storage] setObject:result forKey:self];
+        [[HYPNetworkingStringStorage sharedInstance] storage][self] = result;
         [[[HYPNetworkingStringStorage sharedInstance] lock] unlock];
 
         return result;
@@ -79,7 +79,7 @@
         NSString *result = (remoteStringIsAnAcronym) ? [processedString lowercaseString] : [processedString hyp_lowerCaseFirstLetter];
 
         [[[HYPNetworkingStringStorage sharedInstance] lock] lock];
-        [[[HYPNetworkingStringStorage sharedInstance] storage] setObject:result forKey:self];
+        [[HYPNetworkingStringStorage sharedInstance] storage][self] = result;
         [[[HYPNetworkingStringStorage sharedInstance] lock] unlock];
 
         return result;
@@ -110,7 +110,7 @@
     return [mutableString copy];
 }
 
-- (nonnull NSString *)hyp_replaceIdentifierWithString:(NSString *)replacementString {
+- (nullable NSString *)hyp_replaceIdentifierWithString:(NSString *)replacementString {
     NSScanner *scanner = [NSScanner scannerWithString:self];
     scanner.caseSensitive = YES;
 


### PR DESCRIPTION
When a key contains characters that are not in the defined character sets (e.g. the key `"test_!_key"`), the method `hyp_localString` crashes, because it is assigning the `nil` result to the dictionary (line 82).

This fixes the crash, because changing the dictionary value by using subscription allows assigning `nil`.
