### PR TITLE
Improve/remote string for entity names

### DIFF
--- a/Source/NSString+HYPNetworking.m
+++ b/Source/NSString+HYPNetworking.m
@@ -68,8 +68,8 @@ typedef void (^HYPNetworkingStringStorageBlock)(void);
     if (storedResult) {
         return storedResult;
     } else {
-        NSString *processedString = [self hyp_replaceIdentifierWithString:@"_"];
-        NSString *result = [processedString hyp_lowerCaseFirstLetter];
+        NSString *firstLetterLowercase = [self hyp_lowerCaseFirstLetter];
+        NSString *result = [firstLetterLowercase hyp_replaceIdentifierWithString:@"_"];
 
 		[stringStorage performOnDictionary:^{
 			[stringStorage storage][self] = result;

--- a/Tests/Tests.m
+++ b/Tests/Tests.m
@@ -18,8 +18,7 @@
 
 #pragma mark - Inflections
 
-- (void)testReplacementIdentifier
-{
+- (void)testReplacementIdentifier {
     NSString *testString = @"first_name";
 
     XCTAssertEqualObjects([testString hyp_replaceIdentifierWithString:@""], @"FirstName");
@@ -33,15 +32,13 @@
     XCTAssertEqualObjects([testString hyp_replaceIdentifierWithString:@""], @"UserID");
 }
 
-- (void)testLowerCaseFirstLetter
-{
+- (void)testLowerCaseFirstLetter {
     NSString *testString = @"FirstName";
 
     XCTAssertEqualObjects([testString hyp_lowerCaseFirstLetter], @"firstName");
 }
 
-- (void)testRemoteString
-{
+- (void)testRemoteString {
     NSString *localKey = @"age";
     NSString *remoteKey = @"age";
 
@@ -88,8 +85,7 @@
     XCTAssertEqualObjects(remoteKey, [localKey hyp_remoteString]);
 }
 
-- (void)testLocalString
-{
+- (void)testLocalString {
     NSString *remoteKey = @"age";
     NSString *localKey = @"age";
 
@@ -135,8 +131,7 @@
     XCTAssertNil([remoteKey hyp_localString]);
 }
 
-- (void)testConcurrentAccess
-{
+- (void)testConcurrentAccess {
 	dispatch_queue_t concurrentQueue = dispatch_queue_create("com.hyper.test", DISPATCH_QUEUE_CONCURRENT);
 
 	dispatch_apply(6000, concurrentQueue, ^(const size_t i){

--- a/Tests/Tests.m
+++ b/Tests/Tests.m
@@ -81,6 +81,11 @@
     remoteKey = @"user_id_first";
 
     XCTAssertEqualObjects(remoteKey, [localKey hyp_remoteString]);
+
+    localKey = @"OrderedUser";
+    remoteKey = @"ordered_user";
+
+    XCTAssertEqualObjects(remoteKey, [localKey hyp_remoteString]);
 }
 
 - (void)testLocalString
@@ -130,15 +135,13 @@
     XCTAssertNil([remoteKey hyp_localString]);
 }
 
--(void)testConcurrentAccess {
-
+- (void)testConcurrentAccess
+{
 	dispatch_queue_t concurrentQueue = dispatch_queue_create("com.hyper.test", DISPATCH_QUEUE_CONCURRENT);
 
-	dispatch_apply(65536, concurrentQueue, ^(const size_t i){
-
+	dispatch_apply(6000, concurrentQueue, ^(const size_t i){
 		[self testLocalString];
 		[self testRemoteString];
-
 	});
 
 }


### PR DESCRIPTION
Add support for calling `hyp_remoteString` in entity names, for example `OrderedUser`.
